### PR TITLE
clamp tvc to stay in linearized range

### DIFF
--- a/hardware/TVC.cpp
+++ b/hardware/TVC.cpp
@@ -4,17 +4,18 @@
 
 #include <pigpio.h>
 #include <math.h>
+#include <algorithm.h>
 #include <MissionConstants.hpp>
 #include <iostream>
 #include <string>
 
 void TVC::SetTVCX(double angle_rad)
 {
-    double degrees = (MissionConstants::kTvcXInputCenterAngleDeg + angle_rad) * MissionConstants::kRad2Deg;
+    double degrees = (MissionConstants::kTvcXInputCenterAngleRad + angle_rad) * MissionConstants::kRad2Deg;
+    degees = std::clamp(degrees, -10.0, 10.0);  // Clamp to stay in linearized range.
+
     double servoAngle = -.000095801*powf(degrees, 4) - .0027781*powf(degrees, 3) + .0012874*powf(degrees, 2) - 3.1271*degrees -16.129;
-
-    servoAngle += 90 + MissionConstants::kTvcXCenterAngle;
-
+    servoAngle += 90 + MissionConstants::kTvcXCenterAngleDeg;
 
     double dPulseWidth = 1000 + (servoAngle * 1000 / 180.0);
     gpioServo(23, round(dPulseWidth));
@@ -22,14 +23,11 @@ void TVC::SetTVCX(double angle_rad)
 
 void TVC::SetTVCY(double angle_rad)
 {
-
-    double degrees = (MissionConstants::kTvcYInputCenterAngleDeg + angle_rad) * MissionConstants::kRad2Deg;
+    double degrees = (MissionConstants::kTvcYInputCenterAngleRad + angle_rad) * MissionConstants::kRad2Deg;
+    degees = std::clamp(degrees, -10.0, 10.0);
+    
     double servoAngle = - .0002314576*powf(degrees, 4) - .002425139*powf(degrees, 3) - .01204116*powf(degrees, 2) - 2.959760*degrees + 57.18794;
-
-
-    servoAngle += 90 + MissionConstants::kTvcYCenterAngle;
-    servoAngle = (servoAngle < 0) ? 0 : servoAngle;
-    servoAngle = (servoAngle > 180) ? 180 : servoAngle;
+    servoAngle += 90 + MissionConstants::kTvcYCenterAngleDeg;
 
     double dPulseWidth = 1000 + (servoAngle * 1000 / 180.0);
     gpioServo(24, round(dPulseWidth));

--- a/hardware/TVC.cpp
+++ b/hardware/TVC.cpp
@@ -11,8 +11,8 @@
 
 void TVC::SetTVCX(double angle_rad)
 {
+    angle_rad = std::clamp(angle_rad, -10.0 * MissionConstants.kDeg2Rad, 10.0 * MissionConstants.kDeg2Rad);
     double degrees = (MissionConstants::kTvcXInputCenterAngleRad + angle_rad) * MissionConstants::kRad2Deg;
-    degees = std::clamp(degrees, -10.0, 10.0);  // Clamp to stay in linearized range.
 
     double servoAngle = -.000095801*powf(degrees, 4) - .0027781*powf(degrees, 3) + .0012874*powf(degrees, 2) - 3.1271*degrees -16.129;
     servoAngle += 90 + MissionConstants::kTvcXCenterAngleDeg;
@@ -23,8 +23,8 @@ void TVC::SetTVCX(double angle_rad)
 
 void TVC::SetTVCY(double angle_rad)
 {
+    angle_rad = std::clamp(angle_rad, -10.0 * MissionConstants.kDeg2Rad, 10.0 * MissionConstants.kDeg2Rad);
     double degrees = (MissionConstants::kTvcYInputCenterAngleRad + angle_rad) * MissionConstants::kRad2Deg;
-    degees = std::clamp(degrees, -10.0, 10.0);
     
     double servoAngle = - .0002314576*powf(degrees, 4) - .002425139*powf(degrees, 3) - .01204116*powf(degrees, 2) - 2.959760*degrees + 57.18794;
     servoAngle += 90 + MissionConstants::kTvcYCenterAngleDeg;

--- a/hardware_test/TVC.cpp
+++ b/hardware_test/TVC.cpp
@@ -6,7 +6,7 @@
 
 void TVC::SetTVCX(double dAngle)
 {
-    dAngle += 90 + MissionConstants::kTvcYCenterAngle;
+    dAngle += 90 + MissionConstants::kTvcYCenterAngleDeg;
     dAngle = (dAngle < 0) ? 0 : dAngle;
     dAngle = (dAngle > 180) ? 180 : dAngle;
 
@@ -18,7 +18,7 @@ void TVC::SetTVCX(double dAngle)
 
 void TVC::SetTVCY(double dAngle)
 {
-    dAngle += 90 + MissionConstants::kTvcYCenterAngle;
+    dAngle += 90 + MissionConstants::kTvcYCenterAngleDeg;
     dAngle = (dAngle < 0) ? 0 : dAngle;
     dAngle = (dAngle > 180) ? 180 : dAngle;
 

--- a/include/MissionConstants.hpp
+++ b/include/MissionConstants.hpp
@@ -38,10 +38,10 @@ namespace MissionConstants
 
     const double kControlIntegralPeriod = 0.25;
     const double kDeg2PulseWidth = ((double)1000.0) / ((double)90.0);
-    const double kTvcXCenterAngle = -10;
-    const double kTvcYCenterAngle = -55;
-    const double kTvcYInputCenterAngleDeg = 0.12;
-    const double kTvcXInputCenterAngleDeg = -0.29;
+    const double kTvcXCenterAngleDeg = -10;
+    const double kTvcYCenterAngleDeg = -55;
+    const double kTvcYInputCenterAngleRad = 0.12;
+    const double kTvcXInputCenterAngleRad = -0.29;
     const double TVCPeriod = 0.02;
     const int kTvcXPin = 19;
     const int kTvcYPin = 18;


### PR DESCRIPTION
Clamp TVC angle to stay in linearized range to avoid strange behavior with TVC reversing direction.